### PR TITLE
Playlist modification

### DIFF
--- a/client/trip-frontend/package-lock.json
+++ b/client/trip-frontend/package-lock.json
@@ -8,6 +8,9 @@
       "name": "trip-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@fortawesome/fontawesome-free": "^6.7.1",
         "@types/react-router-dom": "^5.3.3",
         "axios": "^1.7.7",
@@ -346,6 +349,59 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmmirror.com/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmmirror.com/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmmirror.com/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmmirror.com/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -4578,6 +4634,12 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmmirror.com/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/turbo-stream": {
       "version": "2.4.0",

--- a/client/trip-frontend/package.json
+++ b/client/trip-frontend/package.json
@@ -10,6 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@fortawesome/fontawesome-free": "^6.7.1",
     "@types/react-router-dom": "^5.3.3",
     "axios": "^1.7.7",

--- a/client/trip-frontend/src/components/Audio/MainAudioPlayer.tsx
+++ b/client/trip-frontend/src/components/Audio/MainAudioPlayer.tsx
@@ -5,13 +5,15 @@ import { AudioPlayerProps, DownloadResponse, SongObj } from "../../types";
 
 const serverURL = import.meta.env.VITE_SERVER_URL;
 
-const MainAudioPlayer = ({ songs, audioPaused, socket, roomId, partyMode }) => {
+const MainAudioPlayer = ({ songs, audioPaused, socket, roomId, partyMode, onCurrentSongChange }) => {
     const [currentAudioUrl, setCurrentAudioUrl] = useState("")
     const [currentIndex, setCurrentIndex] = useState(0);
     const [progressTime, setProgressTime] = useState(0);
     const [isPlaying, setIsPlaying] = useState(false);
     const [currentTime, setCurrentTime] = useState(0);
     const [duration, setDuration] = useState(0);
+    const [currentSongIndex, setCurrentSongIndex] = useState<number>(0);
+
 
     const [populatedSongInfo, setPopulatedSongInfo] = useState([]);
     const audioRef = useRef(null);
@@ -64,6 +66,7 @@ const MainAudioPlayer = ({ songs, audioPaused, socket, roomId, partyMode }) => {
     }
 
     const handleNext = async () => {
+        // TODO: circle back to the first song if the current index is the last song
         if (currentIndex + 1 >= songs.length) {
             console.log("index out of range, song len: " + songs.length)
             return;
@@ -221,7 +224,21 @@ const MainAudioPlayer = ({ songs, audioPaused, socket, roomId, partyMode }) => {
 
     const getCurrentSong = () => songs[currentIndex];
     const currentSong = getCurrentSong();
+    useEffect(() => {
+        if (songs.length > 0 && currentSongIndex < songs.length) {
+            // Notify parent component about current song change
+            if (onCurrentSongChange) {
+                onCurrentSongChange(currentSongIndex);
+            }
+        }
+    }, [currentSongIndex, songs, onCurrentSongChange]);
 
+    // Notify parent when current index changes
+    useEffect(() => {
+        if (onCurrentSongChange) {
+            onCurrentSongChange(currentIndex);
+        }
+    }, [currentIndex, onCurrentSongChange]);
     return (
         <section className="p-6 bg-[#F8F8F6] relative">
             <div className="flex items-center gap-4">

--- a/client/trip-frontend/src/components/CurrentSongQueue.css
+++ b/client/trip-frontend/src/components/CurrentSongQueue.css
@@ -15,3 +15,39 @@
     background: linear-gradient(to right, #86efac, #4ade80, #22c55e);
     border-radius: 0 0 4px 4px;
 }
+
+/* Drag and drop styles */
+.sortable-item {
+    transition: all 0.2s ease;
+}
+
+.sortable-item:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+.sortable-item:active {
+    cursor: grabbing;
+}
+
+.sortable-item.dragging {
+    opacity: 0.5;
+    transform: rotate(2deg);
+    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
+}
+
+/* Grip handle styles */
+.grip-handle {
+    cursor: grab;
+    color: #9ca3af;
+    transition: color 0.2s ease;
+}
+
+.grip-handle:hover {
+    color: #6b7280;
+}
+
+.grip-handle:active {
+    cursor: grabbing;
+    color: #4b5563;
+}

--- a/client/trip-frontend/src/components/CurrentSongQueue.css
+++ b/client/trip-frontend/src/components/CurrentSongQueue.css
@@ -16,7 +16,6 @@
     border-radius: 0 0 4px 4px;
 }
 
-/* Drag and drop styles */
 .sortable-item {
     transition: all 0.2s ease;
 }
@@ -36,7 +35,6 @@
     box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
 }
 
-/* Grip handle styles */
 .grip-handle {
     cursor: grab;
     color: #9ca3af;
@@ -50,4 +48,36 @@
 .grip-handle:active {
     cursor: grabbing;
     color: #4b5563;
+}
+
+.sortable-item:hover .delete-button {
+    opacity: 1;
+    transform: scale(1.1);
+}
+
+.delete-button {
+    transition: all 0.2s ease-in-out;
+}
+
+.delete-button:hover:not(:disabled) {
+    transform: scale(1.1);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.delete-button:disabled {
+    cursor: not-allowed;
+    opacity: 0.7;
+}
+
+@keyframes spin {
+    from {
+        transform: rotate(0deg);
+    }
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.fa-spinner {
+    animation: spin 1s linear infinite;
 }

--- a/client/trip-frontend/src/components/CurrentSongQueue.css
+++ b/client/trip-frontend/src/components/CurrentSongQueue.css
@@ -18,11 +18,14 @@
 
 .sortable-item {
     transition: all 0.2s ease;
+    border: 1px solid transparent;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
 }
 
 .sortable-item:hover {
     transform: translateY(-1px);
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.6);
+    border-color: rgba(0, 0, 0, 0.05);
 }
 
 .sortable-item:active {
@@ -52,21 +55,62 @@
 
 .sortable-item:hover .delete-button {
     opacity: 1;
-    transform: scale(1.1);
 }
 
 .delete-button {
-    transition: all 0.2s ease-in-out;
+    transition: color 0.2s ease-in-out, text-shadow 0.2s ease-in-out !important;
+    font-weight: 300 !important;
+    font-size: 18px !important;
+    line-height: 1 !important;
+    background: none !important;
+    border: none !important;
+    outline: none !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    box-shadow: none !important;
+    border-radius: 0 !important;
+    position: absolute !important;
+    top: 50% !important;
+    right: 12px !important;
+    transform: translateY(-50%) !important;
+    color: #6b7280 !important;
 }
 
 .delete-button:hover:not(:disabled) {
-    transform: scale(1.1);
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+    color: #000000 !important;
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1) !important;
+    background: none !important;
+    border: none !important;
+    outline: none !important;
+    transform: translateY(-50%) !important;
+    border-color: transparent !important;
+}
+
+.delete-button:active:not(:disabled) {
+    animation: shake 0.5s ease-in-out !important;
 }
 
 .delete-button:disabled {
     cursor: not-allowed;
     opacity: 0.7;
+}
+
+.delete-button:focus,
+.delete-button:focus-visible {
+    outline: none !important;
+    border: none !important;
+    background: none !important;
+    box-shadow: none !important;
+    transform: translateY(-50%) !important;
+}
+
+/* Ensure no movement on any hover state */
+.delete-button:hover,
+.delete-button:active,
+.delete-button:focus {
+    transform: translateY(-50%) !important;
+    top: 50% !important;
+    right: 12px !important;
 }
 
 @keyframes spin {
@@ -75,6 +119,18 @@
     }
     to {
         transform: rotate(360deg);
+    }
+}
+
+@keyframes shake {
+    0%, 100% {
+        transform: translateY(-50%) translateX(0);
+    }
+    10%, 30%, 50%, 70%, 90% {
+        transform: translateY(-50%) translateX(-2px);
+    }
+    20%, 40%, 60%, 80% {
+        transform: translateY(-50%) translateX(2px);
     }
 }
 

--- a/client/trip-frontend/src/components/CurrentSongQueue.css
+++ b/client/trip-frontend/src/components/CurrentSongQueue.css
@@ -1,0 +1,17 @@
+.current-song-playing {
+    background: white;
+    position: relative;
+    font-weight: 600;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.current-song-playing::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 4px;
+    background: linear-gradient(to right, #86efac, #4ade80, #22c55e);
+    border-radius: 0 0 4px 4px;
+}

--- a/client/trip-frontend/src/components/CurrentSongQueue.tsx
+++ b/client/trip-frontend/src/components/CurrentSongQueue.tsx
@@ -5,15 +5,35 @@ import './CurrentSongQueue.css';
 interface CurrentSongQueueProps {
     songs: SongObj[];
     currentSongIndex: number;
+    isHost: boolean;
+    onClearQueue: () => void;
 }
 
 // TODO update the song names with actual added songs
-const CurrentSongQueue: React.FC<CurrentSongQueueProps> = ({ songs, currentSongIndex }) => {
+const CurrentSongQueue: React.FC<CurrentSongQueueProps> = ({ songs, currentSongIndex, isHost, onClearQueue }) => {
 
     return (
         <div className="bg-gray-100 rounded-md mt-2 w-full flex flex-col h-[60vh]">
             <div className="bg-gray-100 p-4 rounded-t-md">
-                <h2 className="text-lg font-semibold mb-2 text-center">Current Song Queue</h2>
+                <div className="flex items-center justify-between mb-2">
+                    <h2 className="text-lg font-semibold text-center flex-1">Current Song Queue</h2>
+                    {isHost && songs.length > 0 && (
+                        <button
+                            onClick={() => {
+                                console.log("Current song stream before clearing:", {
+                                    songsCount: songs.length,
+                                    songs: songs.map(s => s.spotifyData.track?.name),
+                                    currentSongIndex
+                                });
+                                onClearQueue();
+                            }}
+                            className="px-3 py-1 bg-red-500 text-white text-sm rounded-md hover:bg-red-600 transition-colors duration-200 flex items-center gap-1"
+                        >
+                            <i className="fas fa-trash text-xs"></i>
+                            Clear
+                        </button>
+                    )}
+                </div>
             </div>
 
             <div className="flex-1 p-4 overflow-y-auto">
@@ -37,6 +57,12 @@ const CurrentSongQueue: React.FC<CurrentSongQueueProps> = ({ songs, currentSongI
                         </li>
                     ))}
                 </ul>
+                {songs.length === 0 && (
+                    <div className="text-center text-gray-500 py-8">
+                        <i className="fas fa-music text-2xl mb-2"></i>
+                        <p className="text-sm">Add some songs to get started!</p>
+                    </div>
+                )}
             </div>
         </div>
     );

--- a/client/trip-frontend/src/components/CurrentSongQueue.tsx
+++ b/client/trip-frontend/src/components/CurrentSongQueue.tsx
@@ -1,13 +1,18 @@
 import React from 'react';
 import { SongObj } from '../types';
+import './CurrentSongQueue.css';
 
+interface CurrentSongQueueProps {
+    songs: SongObj[];
+    currentSongIndex: number;
+}
 
 // TODO update the song names with actual added songs
-const CurrentSongQueue: React.FC<{songs: SongObj[]}> = ({songs}) => {
+const CurrentSongQueue: React.FC<CurrentSongQueueProps> = ({ songs, currentSongIndex }) => {
 
     return (
         <div className="bg-gray-100 rounded-md mt-2 w-full flex flex-col h-[60vh]">
-            <div className="bg-gray-200 p-4 rounded-t-md">
+            <div className="bg-gray-100 p-4 rounded-t-md">
                 <h2 className="text-lg font-semibold mb-2 text-center">Current Song Queue</h2>
             </div>
 
@@ -16,9 +21,19 @@ const CurrentSongQueue: React.FC<{songs: SongObj[]}> = ({songs}) => {
                     {songs.map((song, index) => (
                         <li
                             key={index}
-                            className="text-gray-700 py-1 px-2 bg-white rounded shadow-sm hover:bg-gray-50"
+                            // highlight the current song
+                            className={`text-gray-700 py-1 px-2 rounded shadow-sm transition-all duration-200 ${
+                                index === currentSongIndex 
+                                    ? 'current-song-playing' 
+                                    : 'bg-white hover:bg-gray-50'
+                            }`}
                         >
                             {index + 1}. {song.spotifyData.track?.name || ""}
+                            {index === currentSongIndex && (
+                                <span className="ml-2 text-green-600">
+                                    <i className="fas fa-play"></i>
+                                </span>
+                            )}
                         </li>
                     ))}
                 </ul>

--- a/client/trip-frontend/src/components/CurrentSongQueue.tsx
+++ b/client/trip-frontend/src/components/CurrentSongQueue.tsx
@@ -60,20 +60,29 @@ const SortableSongItem: React.FC<{
             style={style}
             {...attributes}
             {...listeners}
-            className={`sortable-item text-gray-700 py-1 px-2 rounded shadow-sm transition-all duration-200 cursor-move group relative ${
+            className={`sortable-item text-gray-700 py-2 px-3 rounded-lg shadow-sm transition-all duration-200 cursor-move group relative ${
                 index === currentSongIndex 
                     ? 'current-song-playing' 
                     : 'bg-white hover:bg-gray-50'
             }`}
         >
-            <div className="flex items-center gap-2">
-                <i className="fas fa-grip-vertical text-gray-400 text-xs"></i>
-                <span>{index + 1}. {song.spotifyData.track?.name || ""}</span>
-                {index === currentSongIndex && (
-                    <span className="ml-2 text-green-600">
-                        <i className="fas fa-play"></i>
-                    </span>
-                )}
+            <div className="flex items-center justify-between">
+                <div className="flex items-center gap-3 flex-1">
+                    <i className="fas fa-grip-vertical text-gray-400 text-xs"></i>
+                    <div className="flex-1">
+                        <div className="font-medium text-gray-800 flex items-center gap-2">
+                            {song.spotifyData.track?.name || ""}
+                            {index === currentSongIndex && (
+                                <span className="text-green-600">
+                                    <i className="fas fa-play"></i>
+                                </span>
+                            )}
+                        </div>
+                        <div className="text-sm text-gray-500">
+                            {song.spotifyData.track?.artists?.[0]?.name || ""}
+                        </div>
+                    </div>
+                </div>
             </div>
             
             {/* Delete only visible to host on hover */}
@@ -90,18 +99,15 @@ const SortableSongItem: React.FC<{
                         }
                     }}
                     disabled={isDeletingSong}
-                    className={`delete-button absolute top-1 right-1 opacity-0 group-hover:opacity-100 transition-opacity duration-200 
-                             w-5 h-5 rounded-full flex items-center justify-center text-xs
-                             ${isDeletingSong 
-                                 ? 'bg-gray-400 text-white cursor-not-allowed' 
-                                 : 'bg-red-500 text-white hover:bg-red-600'
-                             }`}
+                    className={`delete-button opacity-0 group-hover:opacity-100 
+                             cursor-pointer
+                             ${isDeletingSong ? 'cursor-not-allowed' : ''}`}
                     title={isDeletingSong ? "Deleting..." : "Delete song"}
                 >
                     {isDeletingSong ? (
-                        <i className="fas fa-spinner fa-spin text-xs"></i>
+                        <i className="fas fa-spinner fa-spin text-sm"></i>
                     ) : (
-                        <i className="fas fa-times"></i>
+                        <span className="text-lg font-light">−</span>
                     )}
                 </button>
             )}
@@ -179,7 +185,7 @@ const CurrentSongQueue: React.FC<CurrentSongQueueProps> = ({
                             items={songs.map((_, index) => index)}
                             strategy={verticalListSortingStrategy}
                         >
-                            <ul className="space-y-1">
+                            <ul className="space-y-2">
                                 {songs.map((song, index) => (
                                     <SortableSongItem
                                         key={index}

--- a/client/trip-frontend/src/components/PlayLists.tsx
+++ b/client/trip-frontend/src/components/PlayLists.tsx
@@ -145,7 +145,7 @@ const PlayLists: React.FC<PlaylistProps> = ({ handleAddToQueue, isOpen, onClose,
         saveCurrentUserSession()
     }
 
-return (
+    return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
         {/* Backdrop */}
         <div
@@ -189,8 +189,6 @@ return (
                                 ></i>
                             </div>
                         </div>
-
-                        <SongSearch handleAddToQueue={handleAddToQueue} isOpen={false} onClose={() => {}} />
                   
                         {/* Playlist Selection */}
                         {showDropdown && (
@@ -308,6 +306,7 @@ return (
             </div>
         </div>
     </div>
-);
+    );
+};
 
 export default PlayLists;

--- a/client/trip-frontend/src/components/PlayLists.tsx
+++ b/client/trip-frontend/src/components/PlayLists.tsx
@@ -117,7 +117,7 @@ const PlayLists: React.FC<PlaylistProps> = ({handleAddToQueue}) => {
 
     return (
         <aside className="w-64 h-screen bg-gray-50 p-4 border-r flex flex-col">
-            <SongSearch handleAddToQueue={handleAddToQueue} />
+            <SongSearch handleAddToQueue={handleAddToQueue} isOpen={false} onClose={() => {}} />
             {authCode ? (
                 <>
                     <div>

--- a/client/trip-frontend/src/components/Popups/SongRemoveModal.tsx
+++ b/client/trip-frontend/src/components/Popups/SongRemoveModal.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+
+interface SongRemoveModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    selectedSongName: string;
+    onRemoveSong: () => void;
+    onRemoveAll: () => void;
+}
+
+const SongRemoveModal: React.FC<SongRemoveModalProps> = ({ 
+    isOpen, 
+    onClose, 
+    selectedSongName, 
+    onRemoveSong, 
+    onRemoveAll 
+}) => {
+    if (!isOpen) return null;
+
+    return (
+        <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-40 backdrop-blur-sm z-50">
+            <div className="bg-white rounded-lg shadow-lg w-80 max-w-sm mx-4">
+                {/* Header with orange gradient */}
+                <div className="bg-gradient-to-r from-orange-500 to-orange-400 p-4 rounded-t-lg">
+                    <div className="flex justify-between items-center">
+                        <div className="flex items-center">
+                            <i className="fas fa-search text-white mr-2"></i>
+                            <span className="text-lg font-semibold text-white">Remove Song</span>
+                        </div>
+                        <button
+                            onClick={onClose}
+                            className="w-8 h-8 rounded-full bg-white bg-opacity-20 hover:bg-opacity-30 transition-all duration-200 flex items-center justify-center"
+                        >
+                            <i className="fas fa-times text-white text-sm"></i>
+                        </button>
+                    </div>
+                </div>
+                
+                {/* Content */}
+                <div className="p-6">
+                    <div className="space-y-4">
+                        <button
+                            onClick={() => {
+                                onRemoveSong();
+                                onClose();
+                            }}
+                            className="w-full text-left p-4 rounded-lg border border-gray-200 hover:bg-gray-50 hover:border-orange-300 transition-all duration-200"
+                        >
+                            <div>
+                                <div className="font-medium text-gray-800">Remove "{selectedSongName}"</div>
+                            </div>
+                        </button>
+                        
+                        <button
+                            onClick={() => {
+                                onRemoveAll();
+                                onClose();
+                            }}
+                            className="w-full text-left p-4 rounded-lg border border-gray-200 hover:bg-gray-50 hover:border-orange-300 transition-all duration-200"
+                        >
+                            <div>
+                                <div className="font-medium text-gray-800">Clear entire playlist</div>
+                            </div>
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default SongRemoveModal;

--- a/client/trip-frontend/src/pages/Room.tsx
+++ b/client/trip-frontend/src/pages/Room.tsx
@@ -317,7 +317,13 @@ export const Room: React.FC<RoomComponentProps> = ({ socket, roomId, setUserJoin
                     onDeleteSong={handleDeleteSong}
                     isDeletingSong={isDeletingSong}
                 />
-                <PlayLists handleAddToQueue={handleAddToQueue} />
+                <PlayLists 
+                    handleAddToQueue={handleAddToQueue} 
+                    isOpen={false}
+                    onClose={() => {}}
+                    roomId={roomId}
+                    saveCurrentUserSession={saveCurrentUserSession}
+                />
 
                 {/* <AudioPlayer songs={[]} currentIndex={1} currentAudioUrl="a" handleNext={null} handlePrevious={null} /> */}
             </div>
@@ -372,7 +378,13 @@ export const Room: React.FC<RoomComponentProps> = ({ socket, roomId, setUserJoin
                     </div>
                 </div>
             </div>
-            <PlayLists handleAddToQueue={handleAddToQueue} />
+            <PlayLists 
+                handleAddToQueue={handleAddToQueue} 
+                isOpen={false}
+                onClose={() => {}}
+                roomId={roomId}
+                saveCurrentUserSession={saveCurrentUserSession}
+            />
         </div>
     )
 }

--- a/client/trip-frontend/src/pages/Room.tsx
+++ b/client/trip-frontend/src/pages/Room.tsx
@@ -17,7 +17,6 @@ const serverURL = import.meta.env.VITE_SERVER_URL;
 
 export const Room: React.FC<RoomComponentProps> = ({ socket, roomId, setUserJoined, currentUser }) => {
     const [playStatus, setPlayStatus] = useState(false);
-    const [progressBar, setProgressBar] = useState(0);
     const [currentQueue, setCurrentQueue] = useState<SongObj[]>([]);
     const [messages, setMessages] = useState<Message[]>([]);
     const [isParty, setIsParty] = useState(true);
@@ -53,19 +52,6 @@ export const Room: React.FC<RoomComponentProps> = ({ socket, roomId, setUserJoin
                 setPlayStatus(audioStatus)
             })
 
-            // socket.on("currentProgress", ({isPaused, pausedAt, startedAt} : {isPaused : boolean, pausedAt : number, startedAt : number}) => {
-            //     if(isPaused){
-            //         console.log("paused at: ", pausedAt);
-            //         setProgressBar(pausedAt);
-            //     }else{
-            //         const currentTime = Date.now();
-            //         const elapsedTime = currentTime - startedAt;
-            //         console.log("currentTime: ", currentTime, " startedAt: ", startedAt, " elapsedTime: ", elapsedTime);
-            //         const progress = (elapsedTime / (pausedAt - startedAt)) * 100;
-            //         setProgressBar(progress);
-            //     }
-            // })
-
             // Listen for incoming messages
             socket.on('receiveMessage', (message: Message) => {
                 setMessages(prev => [...prev, message]);
@@ -83,6 +69,15 @@ export const Room: React.FC<RoomComponentProps> = ({ socket, roomId, setUserJoin
             socket.on('deleteSongError', (error: { message: string }) => {
                 console.error("Delete song error:", error.message);
                 resetDeleteState(); 
+            });
+
+            socket.on('progressSync', (progress: { currentSongIndex: number, currentTime: number, isPaused: boolean }) => {
+                console.log("Room received progress sync:", progress);
+                setCurrentSongIndex(progress.currentSongIndex);
+            });
+
+            socket.on('songIndexUpdated', ({ songIndex, songName }: { songIndex: number, songName: string }) => {
+                setCurrentSongIndex(songIndex);
             });
 
         }

--- a/client/trip-frontend/src/pages/Room.tsx
+++ b/client/trip-frontend/src/pages/Room.tsx
@@ -109,6 +109,16 @@ export const Room: React.FC<RoomComponentProps> = ({ socket, roomId, setUserJoin
         socket.emit("addSongToStream", { selectedTracks, roomId })
     };
 
+    const handleClearQueue = () => {
+        console.log("Current song stream before clearing:", {
+            songsCount: currentQueue.length,
+            songs: currentQueue.map(s => s.spotifyData.track?.name),
+            currentSongIndex
+        });
+        
+        socket.emit("clearQueue", { roomId, username: currentUser });
+    };
+
     const handleSendMessage = (content: string) => {
         if (content) {
             const messageObj: Message = {
@@ -196,7 +206,12 @@ export const Room: React.FC<RoomComponentProps> = ({ socket, roomId, setUserJoin
                     <GuestAudioPlayer />
                 }
                 <FunctionBar handleAddToQueue={handleAddToQueue}/>
-                <CurrentSongQueue songs={currentQueue} currentSongIndex={currentSongIndex} />
+                <CurrentSongQueue 
+                    songs={currentQueue} 
+                    currentSongIndex={currentSongIndex} 
+                    isHost={isHost}
+                    onClearQueue={handleClearQueue}
+                />
                 <PlayLists handleAddToQueue={handleAddToQueue} />
 
                 {/* <AudioPlayer songs={[]} currentIndex={1} currentAudioUrl="a" handleNext={null} handlePrevious={null} /> */}
@@ -234,7 +249,12 @@ export const Room: React.FC<RoomComponentProps> = ({ socket, roomId, setUserJoin
                         :
                         <GuestAudioPlayer />
                     }
-                    <CurrentSongQueue songs={currentQueue} currentSongIndex={currentSongIndex} />
+                    <CurrentSongQueue 
+                        songs={currentQueue} 
+                        currentSongIndex={currentSongIndex} 
+                        isHost={isHost}
+                        onClearQueue={handleClearQueue}
+                    />
                 </div>
 
                 {/* Text Input at the bottom */}

--- a/client/trip-frontend/src/pages/Room.tsx
+++ b/client/trip-frontend/src/pages/Room.tsx
@@ -119,6 +119,10 @@ export const Room: React.FC<RoomComponentProps> = ({ socket, roomId, setUserJoin
         socket.emit("clearQueue", { roomId, username: currentUser });
     };
 
+    const handleReorderQueue = (newOrder: number[]) => {        
+        socket.emit("reorderQueue", { roomId, newOrder });
+    };
+
     const handleSendMessage = (content: string) => {
         if (content) {
             const messageObj: Message = {
@@ -211,6 +215,7 @@ export const Room: React.FC<RoomComponentProps> = ({ socket, roomId, setUserJoin
                     currentSongIndex={currentSongIndex} 
                     isHost={isHost}
                     onClearQueue={handleClearQueue}
+                    onReorderQueue={handleReorderQueue}
                 />
                 <PlayLists handleAddToQueue={handleAddToQueue} />
 
@@ -254,6 +259,7 @@ export const Room: React.FC<RoomComponentProps> = ({ socket, roomId, setUserJoin
                         currentSongIndex={currentSongIndex} 
                         isHost={isHost}
                         onClearQueue={handleClearQueue}
+                        onReorderQueue={handleReorderQueue}
                     />
                 </div>
 

--- a/client/trip-frontend/src/pages/Room.tsx
+++ b/client/trip-frontend/src/pages/Room.tsx
@@ -22,6 +22,7 @@ export const Room: React.FC<RoomComponentProps> = ({ socket, roomId, setUserJoin
     const [messages, setMessages] = useState<Message[]>([]);
     const [isParty, setIsParty] = useState(true);
     const [isHost, setIsHost] = useState<boolean>(true);
+    const [currentSongIndex, setCurrentSongIndex] = useState<number>(0);
 
     useEffect(() => {
         if (socket) {
@@ -183,18 +184,26 @@ export const Room: React.FC<RoomComponentProps> = ({ socket, roomId, setUserJoin
                     }}
                 />
                 {(isParty && isHost || !isParty) ?
-                    <MainAudioPlayer songs={currentQueue} audioPaused={playStatus} socket={socket} roomId={roomId} partyMode={isParty} />
+                    <MainAudioPlayer 
+                        songs={currentQueue} 
+                        audioPaused={playStatus} 
+                        socket={socket} 
+                        roomId={roomId} 
+                        partyMode={isParty}
+                        onCurrentSongChange={setCurrentSongIndex}
+                    />
                     :
                     <GuestAudioPlayer />
                 }
                 <FunctionBar handleAddToQueue={handleAddToQueue}/>
-                <CurrentSongQueue songs={currentQueue} />
+                <CurrentSongQueue songs={currentQueue} currentSongIndex={currentSongIndex} />
                 <PlayLists handleAddToQueue={handleAddToQueue} />
 
                 {/* <AudioPlayer songs={[]} currentIndex={1} currentAudioUrl="a" handleNext={null} handlePrevious={null} /> */}
             </div>
         )
     }
+    // TODO: separate mobile ui and desktop ui
     return (
         <div className="w-screen flex h-screen">
             <JoinedUsers
@@ -214,11 +223,18 @@ export const Room: React.FC<RoomComponentProps> = ({ socket, roomId, setUserJoin
                         <ToggleBtn isParty={isParty} isHost={isHost} setIsParty={setIsParty} />
                     </div>
                     {(isParty && isHost || !isParty) ?
-                        <MainAudioPlayer songs={currentQueue} audioPaused={playStatus} socket={socket} roomId={roomId} partyMode={isParty} />
+                        <MainAudioPlayer 
+                            songs={currentQueue} 
+                            audioPaused={playStatus} 
+                            socket={socket} 
+                            roomId={roomId} 
+                            partyMode={isParty}
+                            onCurrentSongChange={setCurrentSongIndex}
+                        />
                         :
                         <GuestAudioPlayer />
                     }
-                    <CurrentSongQueue songs={currentQueue} />
+                    <CurrentSongQueue songs={currentQueue} currentSongIndex={currentSongIndex} />
                 </div>
 
                 {/* Text Input at the bottom */}

--- a/client/trip-frontend/src/types/index.ts
+++ b/client/trip-frontend/src/types/index.ts
@@ -54,6 +54,7 @@ export type AudioPlayerProps = {
     socket: Socket,
     roomId : string,
     partyMode:boolean;
+    onCurrentSongChange?: (index: number) => void;
 }
 
 export type ToggleProps = {

--- a/server/src/sockets.ts
+++ b/server/src/sockets.ts
@@ -156,18 +156,41 @@ export default function initSockets(httpServer: HTTPServer) {
                 return;
             }
             
-            console.log("🚀 Clear Queue request from host:", username, "for room:", roomId);
+            console.log("Clear Queue request from host:", username, "for room:", roomId);
             
             // Clear the queue
             const clearedQueue = rooms[roomId].clearQueue();
             
-            console.log("📊 Current song stream after clearing:", {
+            console.log("Current song stream after clearing:", {
                 songsCount: clearedQueue.length,
                 songs: clearedQueue.map(s => s.spotifyData.track?.name)
             });
             
             // Update all clients in the room
             updateCurrentSongQueue(clearedQueue, roomId);
+        })
+
+        socket.on("reorderQueue", ({roomId, newOrder} : {roomId : string, newOrder: number[]}) => {
+            if (!rooms[roomId]) {
+                console.error("No such room exist");
+                return;
+            }
+            
+            console.log("Current song stream before reordering:", {
+                songsCount: rooms[roomId].getSongStream.length,
+                songs: rooms[roomId].getSongStream.map(s => s.spotifyData.track?.name)
+            });
+            
+            // Reorder the queue
+            const reorderedQueue = rooms[roomId].reorderQueue(newOrder);
+            
+            console.log("Current song stream after reordering:", {
+                songsCount: reorderedQueue.length,
+                songs: reorderedQueue.map(s => s.spotifyData.track?.name)
+            });
+            
+            // Update all clients in the room
+            updateCurrentSongQueue(reorderedQueue, roomId);
         })
 
         socket.on("pauseAndPlayEvent", ({roomId, isPaused, progressTime} : {roomId : string, isPaused : boolean, progressTime : number}) => {

--- a/server/src/sockets.ts
+++ b/server/src/sockets.ts
@@ -34,8 +34,9 @@ export default function initSockets(httpServer: HTTPServer) {
         // return current song queue of the room
         io.to(roomId).emit("getCurrentSongStream", [...rooms[roomId].getSongStream])
 
-        // return currnet song playing time
-        io.to(roomId).emit("currentProgress", rooms[roomId].getCurrentProgress);
+        // return current song playing progress
+        const progress = rooms[roomId].getCurrentProgress();
+        io.to(roomId).emit("progressSync", progress);
     }
 
     const updateCurrentSongQueue = (newSongs : SongObj[], roomId : string) => {
@@ -197,6 +198,58 @@ export default function initSockets(httpServer: HTTPServer) {
             updateCurrentSongQueue(updatedQueue, roomId);
         })
 
+        socket.on("updateSongIndex", ({roomId, songIndex} : {roomId : string, songIndex : number}) => {           
+            // Update the current song index
+            rooms[roomId].updateCurrentSongIndex(songIndex);
+            
+            io.to(roomId).emit("songIndexUpdated", {
+                songIndex: songIndex,
+                songName: rooms[roomId].getSongStream[songIndex]?.spotifyData.track?.name
+            });
+        })
+
+        socket.on("startPlayback", ({roomId} : {roomId : string}) => {
+            
+            console.log("Start playback request for room:", roomId);
+            
+            // Start playback tracking
+            rooms[roomId].startSongPlayback();
+            
+            io.to(roomId).emit("playbackStarted", rooms[roomId].getCurrentProgress());
+        })
+
+        socket.on("pausePlayback", ({roomId} : {roomId : string}) => {
+            if (!rooms[roomId]) {
+                console.error("No such room exist");
+                return;
+            }
+            
+            console.log("Pause playback request for room:", roomId);
+            
+            // Pause playback tracking
+            rooms[roomId].pauseSongPlayback();
+            
+            io.to(roomId).emit("playbackPaused", rooms[roomId].getCurrentProgress());
+        })
+
+        socket.on("requestProgressSync", ({roomId} : {roomId : string}) => {
+            if (!rooms[roomId]) {
+                console.error("No such room exist");
+                return;
+            }
+                        
+            // Send current progress to the requesting client
+            const progress = rooms[roomId].getCurrentProgress();
+            socket.emit("progressSync", progress);
+            
+            console.log("Sent progress sync:", {
+                roomId,
+                currentSongIndex: progress.currentSongIndex,
+                currentTime: progress.currentTime,
+                isPaused: progress.isPaused
+            });
+        })
+
         socket.on("reorderQueue", ({roomId, username, newOrder} : {roomId : string, username : string, newOrder: SpotifyApi.PlaylistTrackObject[]}) => {
             if (!rooms[roomId]) {
                 console.error("No such room exist");
@@ -221,20 +274,16 @@ export default function initSockets(httpServer: HTTPServer) {
             if(isPaused == null || !rooms[roomId]) return;
 
             console.log("progressTime: ", progressTime, " isPaused: ", isPaused);
-            rooms[roomId].isPaused = isPaused;
-
+            
             if(isPaused){
-                rooms[roomId].pasuedAt = Date.now() - rooms[roomId].startedAt;
+                rooms[roomId].pauseSongPlayback();
+                io.to(roomId).emit("playbackPaused", rooms[roomId].getCurrentProgress());
             }else{
-                rooms[roomId].startedAt = Date.now() - rooms[roomId].pasuedAt;
-                rooms[roomId].pasuedAt = 0;
+                rooms[roomId].startSongPlayback();
+                io.to(roomId).emit("playbackStarted", rooms[roomId].getCurrentProgress());
             }
-            socket.to(roomId).emit("currentProgress", {
-                isPaused: rooms[roomId].isPaused,
-                pausedAt: rooms[roomId].pasuedAt,
-                startedAt: rooms[roomId].startedAt
-            });
-            socket.to(roomId).emit('updatePlayingStatus', isPaused);
+            
+            io.to(roomId).emit('updatePlayingStatus', isPaused);
         })
 
         socket.on("changeRoomType", ({roomId, isParty} : {roomId : string, isParty : boolean}) => {

--- a/server/src/sockets.ts
+++ b/server/src/sockets.ts
@@ -145,6 +145,31 @@ export default function initSockets(httpServer: HTTPServer) {
             }
         })
 
+        socket.on("clearQueue", ({roomId, username} : {roomId : string, username : string}) => {
+            if (!rooms[roomId]) {
+                console.error("No such room exist");
+                return;
+            }
+            
+            // Check if user is host
+            if (rooms[roomId].hostID !== username) {
+                return;
+            }
+            
+            console.log("🚀 Clear Queue request from host:", username, "for room:", roomId);
+            
+            // Clear the queue
+            const clearedQueue = rooms[roomId].clearQueue();
+            
+            console.log("📊 Current song stream after clearing:", {
+                songsCount: clearedQueue.length,
+                songs: clearedQueue.map(s => s.spotifyData.track?.name)
+            });
+            
+            // Update all clients in the room
+            updateCurrentSongQueue(clearedQueue, roomId);
+        })
+
         socket.on("pauseAndPlayEvent", ({roomId, isPaused, progressTime} : {roomId : string, isPaused : boolean, progressTime : number}) => {
             if(isPaused == null || !rooms[roomId]) return;
 

--- a/server/src/types/room.ts
+++ b/server/src/types/room.ts
@@ -65,6 +65,13 @@ export class RoomInfo{
         return this.songStream;
     }
 
+    public clearQueue() {
+        console.log("🎵 Clearing queue for room:", this.roomID);
+        this.songStream = [];
+        console.log("📊 Songs after clearing:", this.songStream.length);
+        return this.songStream;
+    }
+
     public removeSongToStream(selectedSong : SpotifyApi.PlaylistTrackObject){
         // TODO
     }

--- a/server/src/types/room.ts
+++ b/server/src/types/room.ts
@@ -9,6 +9,7 @@ export class RoomInfo{
     isParty: boolean;
     pasuedAt : number;
     startedAt : number;
+    currentSongIndex: number;
     requiresPassword : boolean;
     password? : string;
 
@@ -28,6 +29,7 @@ export class RoomInfo{
         this.isParty = true;
         this.pasuedAt = 0;
         this.startedAt = 0;
+        this.currentSongIndex = 0;
     }
 
     /**
@@ -111,11 +113,38 @@ export class RoomInfo{
     }
 
     public getCurrentProgress() {
+        const currentTime = this.isPaused ? this.pasuedAt : Date.now() - this.startedAt;
         return {
             isPaused : this.isPaused,
             pasuedAt: this.pasuedAt,
-            startedAt : this.startedAt
+            startedAt : this.startedAt,
+            currentTime: Math.max(0, currentTime),
+            currentSongIndex: this.currentSongIndex
         }
     }
 
+    public updateCurrentSongIndex(index: number) {
+        this.currentSongIndex = index;
+    }
+
+    public startSongPlayback() {
+        console.log("Starting song playback:", {
+            roomId: this.roomID,
+            songIndex: this.currentSongIndex,
+            songName: this.songStream[this.currentSongIndex]?.spotifyData.track?.name
+        });
+        this.startedAt = Date.now();
+        this.pasuedAt = 0;
+        this.isPaused = false;
+    }
+
+    public pauseSongPlayback() {
+        console.log("Pausing song playback:", {
+            roomId: this.roomID,
+            songIndex: this.currentSongIndex,
+            songName: this.songStream[this.currentSongIndex]?.spotifyData.track?.name
+        });
+        this.pasuedAt = Date.now() - this.startedAt;
+        this.isPaused = true;
+    }
 }

--- a/server/src/types/room.ts
+++ b/server/src/types/room.ts
@@ -66,9 +66,21 @@ export class RoomInfo{
     }
 
     public clearQueue() {
-        console.log("🎵 Clearing queue for room:", this.roomID);
+        console.log("Clearing queue for room:", this.roomID);
         this.songStream = [];
-        console.log("📊 Songs after clearing:", this.songStream.length);
+        console.log("Songs after clearing:", this.songStream.length);
+        return this.songStream;
+    }
+
+    public reorderQueue(newOrder: number[]) {        
+        if (newOrder.length !== this.songStream.length) {
+            return this.songStream;
+        }
+        
+        // Create new array with reordered songs
+        const reorderedSongs = newOrder.map(index => this.songStream[index]);
+        this.songStream = reorderedSongs;
+        
         return this.songStream;
     }
 

--- a/server/src/types/room.ts
+++ b/server/src/types/room.ts
@@ -72,14 +72,36 @@ export class RoomInfo{
         return this.songStream;
     }
 
-    public reorderQueue(newOrder: number[]) {        
-        if (newOrder.length !== this.songStream.length) {
-            return this.songStream;
-        }
+    public reorderQueue(newOrder: SpotifyApi.PlaylistTrackObject[]) {
+        console.log("Songs before reordering:", this.songStream.length);
         
-        // Create new array with reordered songs
-        const reorderedSongs = newOrder.map(index => this.songStream[index]);
-        this.songStream = reorderedSongs;
+        const newSongStream: SongObj[] = newOrder.map((track) => ({
+            spotifyData: track,
+        }));
+        
+        this.songStream = newSongStream;
+        console.log("Songs after reordering:", this.songStream.length);
+        return this.songStream;
+    }
+
+    public deleteSong(songIndex: number) {
+        console.log("Deleting song from queue:", {
+            roomId: this.roomID,
+            songIndex,
+            songName: this.songStream[songIndex]?.spotifyData.track?.name,
+            totalSongsBefore: this.songStream.length
+        });
+        
+        if (songIndex >= 0 && songIndex < this.songStream.length) {
+            const deletedSong = this.songStream[songIndex];
+            this.songStream.splice(songIndex, 1);
+            console.log("Song deleted successfully:", {
+                deletedSong: deletedSong?.spotifyData.track?.name,
+                totalSongsAfter: this.songStream.length
+            });
+        } else {
+            console.error("Invalid song index:", songIndex, "SongStream length:", this.songStream.length);
+        }
         
         return this.songStream;
     }


### PR DESCRIPTION
1. Be able to clean up the current playlist(only host)
2. Enable drag and drop the songs to switch up which song to play next(everyone), utilize https://docs.dndkit.com/presets/sortable
3. Be able to delete a single song when hover over that song (only host)
4. Highlight the current song playing in the list
5. Sync the progress bar across rooms( a sync indicator on top to show sync status)

TODO: if users are physically in one room, others can toggle on party mode so only one person's audio is pla
<img width="439" height="537" alt="截屏2025-08-27 12 15 47" src="https://github.com/user-attachments/assets/a24f89b7-c666-4e3c-8eff-c346857f2642" />
<img width="438" height="510" alt="截屏2025-08-27 12 15 50" src="https://github.com/user-attachments/assets/99eb8927-46fc-4e5e-90d1-90ae5f5594f8" />
<img width="511" height="447" alt="截屏2025-08-27 12 16 04" src="https://github.com/user-attachments/assets/a0935308-cc90-4892-9a93-3b680b06960c" />
ying. In other words, if party mod is on for a user, then he/she's device is not playing the music.
