### PR TITLE
drag -> duplicate bug fix

### DIFF
--- a/client/trip-frontend/src/pages/Room.tsx
+++ b/client/trip-frontend/src/pages/Room.tsx
@@ -48,7 +48,7 @@ export const Room: React.FC<RoomComponentProps> = ({ socket, roomId, setUserJoin
             // Playlist management
             socket.on("updateSongStream", (songStream: SongObj[]) => {
                 console.log("Song stream updated: ", songStream);
-                setCurrentQueue((prev) => [...prev, ...songStream])
+                setCurrentQueue(songStream)
                 resetDeleteState(); 
             })
             socket.on("getCurrentSongStream", (songStream: SongObj[]) => {
@@ -152,7 +152,7 @@ export const Room: React.FC<RoomComponentProps> = ({ socket, roomId, setUserJoin
         socket.emit("reorderQueue", { 
             roomId, 
             username: currentUser,
-            newOrder: newOrder.map(song => song.spotifyData)
+            newOrder: newOrder
         });
     };
 

--- a/server/src/sockets.ts
+++ b/server/src/sockets.ts
@@ -45,7 +45,8 @@ export default function initSockets(httpServer: HTTPServer) {
 
     const addSongToStream = (roomID : string, selectedTracks: SpotifyApi.PlaylistTrackObject[]) => {
         const newSongs = rooms[roomID].addSongToStream(selectedTracks);
-        updateCurrentSongQueue(newSongs, roomID)
+        // Send the entire updated queue
+        updateCurrentSongQueue(rooms[roomID].getSongStream, roomID)
     };
 
     const removeSongFromStream = () => {
@@ -254,7 +255,7 @@ export default function initSockets(httpServer: HTTPServer) {
             });
         })
 
-        socket.on("reorderQueue", ({roomId, username, newOrder} : {roomId : string, username : string, newOrder: SpotifyApi.PlaylistTrackObject[]}) => {
+        socket.on("reorderQueue", ({roomId, username, newOrder} : {roomId : string, username : string, newOrder: SongObj[]}) => {
             if (!rooms[roomId]) {
                 console.error("No such room exist");
                 return;

--- a/server/src/types/room.ts
+++ b/server/src/types/room.ts
@@ -74,14 +74,10 @@ export class RoomInfo{
         return this.songStream;
     }
 
-    public reorderQueue(newOrder: SpotifyApi.PlaylistTrackObject[]) {
+    public reorderQueue(newOrder: SongObj[]) {
         console.log("Songs before reordering:", this.songStream.length);
         
-        const newSongStream: SongObj[] = newOrder.map((track) => ({
-            spotifyData: track,
-        }));
-        
-        this.songStream = newSongStream;
+        this.songStream = [...newOrder];
         console.log("Songs after reordering:", this.songStream.length);
         return this.songStream;
     }


### PR DESCRIPTION
Instead of adding new songs to playlist, replace the entire song stream to avoid duplicate.
unify backend sending and frontend receiving SongObj[]  , not SpotifyApi.PlaylistTrackObject[], ensuring audio url is not missing