### PR TITLE
Code cleanup

### DIFF
--- a/client/trip-frontend/src/components/CurrentSongQueue.css
+++ b/client/trip-frontend/src/components/CurrentSongQueue.css
@@ -36,10 +36,13 @@
     cursor: grabbing;
 }
 
-.sortable-item.dragging {
-    opacity: 0.5;
-    transform: rotate(2deg);
-    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
+/* Smooth dragging styles - less restrictive */
+.sortable-item[data-dragging="true"] {
+    opacity: 0.8;
+    transform: rotate(1deg) scale(1.02);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+    z-index: 1000;
+    transition: opacity 0.1s ease;
 }
 
 .delete-background {
@@ -67,43 +70,60 @@
 .song-content-wrapper {
     position: relative;
     z-index: 2;
-    background: white;
-    transition: transform 0.2s ease;
+    background: inherit;
+    transition: transform 0.15s ease;
+    border-radius: inherit;
+}
+
+/* Only disable swipe transform during active drag, not hover */
+.sortable-item[data-dragging="true"] .song-content-wrapper {
+    transform: translateX(0) !important;
 }
 
 .drag-handle {
     cursor: grab;
     color: #9ca3af;
-    transition: color 0.2s ease;
-    padding: 4px;
+    transition: all 0.15s ease;
+    padding: 8px 4px;
     border-radius: 4px;
     touch-action: none;
     user-select: none;
+    margin: -4px 0;
 }
 
 .drag-handle:hover {
     color: #6b7280;
     background-color: rgba(0, 0, 0, 0.05);
+    transform: scale(1.1);
 }
 
 .drag-handle:active {
     cursor: grabbing;
     color: #4b5563;
+    transform: scale(0.95);
 }
 
-/* Right side area for swipe detection */
 .swipe-area {
     position: absolute;
     top: 0;
     right: 0;
     bottom: 0;
-    left: 50%;
+    left: 40%;
     z-index: 3;
     cursor: grab;
 }
 
 .swipe-area:active {
     cursor: grabbing;
+}
+
+/* Subtle animation improvements */
+.sortable-item {
+    will-change: transform;
+}
+
+.sortable-item * {
+    will-change: auto;
 }
 
 @keyframes spin {

--- a/client/trip-frontend/src/spotify/SpotifyUseAuth.ts
+++ b/client/trip-frontend/src/spotify/SpotifyUseAuth.ts
@@ -38,7 +38,6 @@ export const useAuth = () => {
 
     // exchange auth code for access token
     useEffect(() => {
-        console.log("auth code changed")
         const fetchAccessToken = async () => {
             try {
                 if (authCode && !accessToken) {


### PR DESCRIPTION
A code clean-up from #62 
Only Room.tsx in the frontend and Room object in the backend keep track of the index of the current song

Original implementations keep track of the following:
    const [currentIndex, setCurrentIndex] = useState(0);
    const [currentSongIndex, setCurrentSongIndex] = useState<number>(0);
    const [currentSongIndex, setCurrentSongIndex] = useState<number>(0);
    
Now the cleaned-up version only keeps track of:
const [currentIndex, setCurrentIndex] = useState(0);

We only have one currentIndex in the frontend.

This cleanup also makes it easier to fix the index issue that inevitably originated from #62, which is index is not updated when the user dragged and resorted the song queues. Because now we only have to keep track of one **currentIndex**, it is extremely easy to update the currentIndex across different rooms.

We only need one socket event, and one useState